### PR TITLE
在 PDF 书签中显示章节序号

### DIFF
--- a/appendix/updateinfo.tex
+++ b/appendix/updateinfo.tex
@@ -2,6 +2,12 @@
 
 \chapter{版本信息}
 
+\section*{未发布}
+
+\begin{enumerate}
+  \item 在 PDF 书签中显示章节序号
+\end{enumerate}
+
 \section*{v2023.5.1}
 
 \begin{enumerate}

--- a/install-latex-guide-zh-cn.tex
+++ b/install-latex-guide-zh-cn.tex
@@ -4,7 +4,7 @@
 \usepackage{listings}
 \usepackage{xcolor}
 \usepackage{fontawesome5}
-\usepackage[pdfpagelayout=SinglePage]{hyperref}
+\usepackage[pdfpagelayout=SinglePage,bookmarksnumbered]{hyperref}
 \usepackage[os=win,hyperrefcolorlinks]{menukeys}
 
 \ctexset{
@@ -12,6 +12,7 @@
     format       = \huge\bfseries\raggedright,
     number       = \arabic{chapter},
     name         = {},
+    tocline      = \CTEXifname{\protect\numberline{\thechapter}}{}#2,
   },
   section/format = \Large\bfseries\raggedright,
 }


### PR DESCRIPTION
附带的修改：为美观，我想在书签里去掉「附录」字样，同时序号和标题之间只保留一个空格。通过修改 `chapter/tocline`，把 `\CTEXthechapter\hspace{.3em}` 换成 `\thechapter` 实现，但目录一并受到了。

只修改书签是可能的，但需要 patch `hyperref` 的内部，我觉得对于小文档不值。

| | 修改前 | 仅添加 <code>bookmarksnumbered</code> | 还设置 <code>chapter/tocline</code> |
|--------|--------|--------|--------|
| 书签 | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/a58da10b-063d-4ed4-880f-990fbdb8938f) | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/81e20aaa-5f4a-4ddf-8fa3-ea863003f856) | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/c5bc1d9c-4ea9-47ab-b75f-fdc717247ecf) |
| 目录 | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/9357ad22-0e1b-49d4-b7dd-08854b66a521) | 不变 | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/d5558e8a-6850-45f9-85d6-3093bf27ed7d) |
| 内页 | ![image](https://github.com/OsbertWang/install-latex-guide-zh-cn/assets/6376638/689e673a-6362-4899-b33a-0daf040379a4) | 不变 | 不变 |