### PR TITLE
Ubuntu环境变量问题和其他小错误修改

### DIFF
--- a/chapter/ubuntu.tex
+++ b/chapter/ubuntu.tex
@@ -134,8 +134,9 @@
   export MANPATH=/usr/local/texlive/2023/texmf-dist/doc/man:$MANPATH
   export INFOPATH=/usr/local/texlive/2023/texmf-dist/doc/info:$INFOPATH
 \end{lstlisting}
-保存退出.
-这时重新打开 \textsf{Terminal} 执行
+并保存退出.
+然后退出登录当前用户并重新登录,
+再打开 \textsf{Terminal} 并执行
 \begin{lstlisting}[language=bash]
   tex -v
 \end{lstlisting}

--- a/chapter/windows.tex
+++ b/chapter/windows.tex
@@ -244,7 +244,7 @@
 \subsection{系统用中文作为用户名}\label{sec:chinesename}
 
 很多中文 Windows 用户习惯于用中文作为用户名,
-但是这样会导致 \TeX{} Live 2022 安装失败.
+但是这样会导致 \TeX{} Live 安装失败.
 更改系统的 \texttt{TEMP} 和 \texttt{TMP} 这两个环境变量可以避免这样的问题.
 在 \textsf{cmd} 中执行
 \begin{lstlisting}
@@ -253,7 +253,7 @@
   set TMP=C:\temp
 \end{lstlisting}
 便可更改这两个环境变量为 \texttt{C:\textbackslash temp}.
-更改后按照前述内容安装 \TeX{} Live 2022 即可.
+更改后按照前述内容安装 \TeX{} Live 即可.
 这样的更改是临时的,
 待 \textsf{cmd} 窗口关闭,
 环境变量将恢复为原始状态.


### PR DESCRIPTION
## Ubuntu环境变量问题
第2.1节，16页，在 `~/.profile` 文件中添加了环境变量后，应退出登录再重新登录，才能使 `~/.profile` 中的内容生效，因为 `~/.profile` 中的内容是 login shell 才会执行的，系统重新登录，就会生效，而如果只是重启 Terminal，因为终端模拟器不是 login shell，所以不会生效。

因此，我将原文 
```
保存退出. 这时重新打开 Terminal 执行
``` 
修改为 
```
并保存退出. 然后退出登录当前用户并重新登录, 再打开 Terminal 并执行
```

## 其他小错误
第 1.1.3 节，原文写的 TeX Live 2022 应改为 TeX Live 2023，但考虑到后续 TeX Live 的持续更新，故建议去掉年份。
