### PR TITLE
Updated the preamble and macOS part of the manual.

### DIFF
--- a/chapter/macos.tex
+++ b/chapter/macos.tex
@@ -193,7 +193,14 @@ Homebrew 安装教程可以在其网站找到,
 \begin{lstlisting}
   brew uninstall mactex
 \end{lstlisting}
-卸载很成功,
+
+如果用户借助 Homebrew 安装 Mac\TeX{} 时选择仅安装其命令行工具,
+卸载时需使用
+\begin{lstlisting}[language=bash]
+  brew uninstall mactex-no-gui
+\end{lstlisting}
+
+以上卸载均很成功,
 只是有一些残留.
 
 \section{跨版本升级 Mac\TeX}
@@ -204,14 +211,15 @@ Homebrew 安装教程可以在其网站找到,
 或者干脆保留多个版本,
 具体见\href{https://www.tug.org/mactex/multipletexdistributions.html}{这里}.
 
-如果用户借助 Homebrew cask 安装了 Mac\TeX,
+如果用户借助 Homebrew 安装了 Mac\TeX,
 跨版本升级 (Mac\TeX{} 的版本与 \TeX{} Live 保持一致), 可在\textsf{终端}借助 Homebrew 完成:
 \begin{lstlisting}[language=bash]
   brew update
   brew upgrade mactex
 \end{lstlisting}
 
-如果安装 Mac\TeX{} 时选择仅安装 Mac\TeX{} 的命令行工具 (\texttt{-no-gui}), 跨版本升级时需输入
+如果用户借助 Homebrew 安装 Mac\TeX{} 时选择仅安装其命令行工具,
+跨版本升级时需使用
 \begin{lstlisting}[language=bash]
   brew update
   brew upgrade mactex-no-gui

--- a/install-latex-guide-zh-cn.tex
+++ b/install-latex-guide-zh-cn.tex
@@ -4,8 +4,8 @@
 \usepackage{listings}
 \usepackage{xcolor}
 \usepackage{fontawesome5}
-\usepackage[pdfpagelayout=SinglePage,bookmarksnumbered]{hyperref}
-\usepackage[os=win,hyperrefcolorlinks]{menukeys}
+\usepackage[colorlinks,pdfpagelayout=SinglePage,bookmarksnumbered]{hyperref}
+\usepackage[os=win]{menukeys}
 \usepackage[nolinks]{qrcode}
 
 \ctexset{


### PR DESCRIPTION
- Updated the description of the macOS part.
- Removed the obsoleted `hyperrefcolorlinks` option of the `menukeys` package, and used `colorlinks` of hyperref instead. (Otherwise, it will return a warning: `The option 'hyperrefcolorlinks' is obsolete`. See [menukeys: 6.4.1 `hyperref`'s `colorlinks` option](https://mirrors.jlu.edu.cn/CTAN/macros/latex/contrib/menukeys/menukeys.pdf#page17) for more.