### PR TITLE
更新了 build.lua 和工作流

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -16,7 +16,7 @@ jobs:
   cache:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     name: Update TeX Live
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           package_file: .github/tl_packages
       - name: Run l3build
-        run: l3build ctan
+        run: l3build ctan -q -H

--- a/build.lua
+++ b/build.lua
@@ -10,55 +10,33 @@
 module           = "install-latex-guide-zh-cn"
 version          = "v2025.5.1"
 maintainer       = "Ran Wang"
+uploader         = maintainer
 maintainid       = "OsbertWang"
 email            = "ranwang.osbert@outlook.com"
 repository       = "https://github.com/" .. maintainid .. "/" .. module
 announcement     = ""
 summary          = "A short introduction to LaTeX installation written in Chinese"
 description      = [[
-This package will introduce the operations related to installing TeX Live
-(introducing MacTeX in macOS), upgrading packages, and compiling simple documents on Windows 11, Ubuntu 22.04, and macOS systems, and mainly introducing command line operations.
+This package will introduce the operations related to installing TeX Live (introducing MacTeX in macOS), upgrading packages, and compiling simple documents on Windows 11, Ubuntu 22.04, and macOS systems, and mainly introducing command line operations.
 ]]
 
 --[==========================================[--
             Pack and Upload To CTAN
          Don't Modify Unless Necessary
 --]==========================================]--
+ctanzip          = module
+excludefiles     = {"*~"}
+textfiles        = {"*.md", "LICENSE", "*.lua", "*.bat", "makefile"}
 typesetexe       = "xelatex"
 typesetfiles     = {module .. ".tex"}
-supportdir       = "chapter"
 typesetsuppfiles = {"*.tex"}
-textfiles        = {"*.md", "LICENSE", "*.lua", "*.bat", "makefile"}
-excludefiles     = {"*~"}
-cleanfiles       = {"*.log", "*.pdf", "*.zip", "*.curlopt"}
-ctanzip          = module
-
-function copyctan()
-  local pkgsuppdir = ctandir .. "/" .. ctanpkg .. "/" .. supportdir
-  mkdir(pkgsuppdir)
-  for _,supptab in pairs(typesetsuppfiles) do
-    cp(supptab, supportdir, pkgsuppdir)
-  end
-  local pkgdir = ctandir .. "/" .. ctanpkg
-  mkdir(pkgdir)
-  local function copyfiles(files,source)
-    for _,filetype in pairs(files) do
-      cp(filetype,source,pkgdir)
-    end
-  end
-  for _,tab in pairs({pdffiles,typesetlist}) do
-    copyfiles(tab,docfiledir)
-  end
-  for _,file in pairs(textfiles) do
-    cp(file, textfiledir, pkgdir)
-  end
-end
+supportdir       = "chapter"
 
 uploadconfig = {
   pkg          = module,
   version      = version,
   author       = maintainer,
-  uploader     = maintainer,
+  uploader     = uploader,
   email        = email,
   summary      = summary,
   description  = description,
@@ -72,3 +50,26 @@ uploadconfig = {
   development  = "https://github.com/" .. maintainid,
   update       = true
 }
+
+function docinit_hook()
+  local docsuppdir = typesetdir .. "/" .. supportdir
+  mkdir(docsuppdir)
+  for _,supp in pairs(typesetsuppfiles) do
+    cp(supp, supportdir, docsuppdir)
+    rm(typesetdir, supp)
+  end
+  cp(module .. ".tex", currentdir, typesetdir)
+  return 0
+end
+function copyctan()
+  local pkgdir = ctandir .. "/" .. ctanpkg
+  mkdir(pkgdir)
+  for _,main in pairs({module .. ".tex", module .. ".pdf"}) do
+    cp(main, typesetdir, pkgdir)
+  end
+  local pkgsuppdir = ctandir .. "/" .. ctanpkg .. "/" .. supportdir
+  mkdir(pkgsuppdir)
+  for _,supptab in pairs(typesetsuppfiles) do
+    cp(supptab, supportdir, pkgsuppdir)
+  end
+end

--- a/build.lua
+++ b/build.lua
@@ -8,7 +8,7 @@
              Do Check Before Upload
 --]==========================================]--
 module           = "install-latex-guide-zh-cn"
-version          = "v2025.5.1"
+version          = "2025.5.1"
 maintainer       = "Ran Wang"
 uploader         = maintainer
 maintainid       = "OsbertWang"

--- a/install-latex-guide-zh-cn.tex
+++ b/install-latex-guide-zh-cn.tex
@@ -112,10 +112,6 @@
                       emphstyle = {}, keywordstyle = {} ] {"}
 \VerbatimFootnotes
 
-\newcommand\buildinclude[1]{%
-  \InputIfFileExists{#1}{}{\include{./chapter/#1}}
-}
-
 \title{\bfseries 一份简短的关于 \LaTeX\ 安装的介绍%
   \thanks{\url{https://github.com/OsbertWang/install-latex-guide-zh-cn}}%
 }
@@ -129,22 +125,22 @@
 
 \maketitle
 
-\buildinclude{preface}
+\include{./chapter/preface}
 
 \tableofcontents
 
-\buildinclude{windows}
-\buildinclude{ubuntu}
-\buildinclude{macos}
-\buildinclude{wsl}
-\buildinclude{editor}
-\buildinclude{overleaf}
+\include{./chapter/windows}
+\include{./chapter/ubuntu}
+\include{./chapter/macos}
+\include{./chapter/wsl}
+\include{./chapter/editor}
+\include{./chapter/overleaf}
 
 \appendix
 
-\buildinclude{mirror}
-\buildinclude{addition}
-\buildinclude{offline}
-\buildinclude{updateinfo}
+\include{./chapter/mirror}
+\include{./chapter/addition}
+\include{./chapter/offline}
+\include{./chapter/updateinfo}
 
 \end{document}


### PR DESCRIPTION
- 使用 `l3build-typesetting.lua` 中提供的钩子 `docinit_hook()` 函数在 `./build/doc` 中时建立 `./chapter` 路径，使 build 过程中在 typeset 时可找到 `./chapter/*.tex`，此时无需 `\buildinclude` 命令，使用原始的 `\include` 命令即可
- 优化 `copyctan()` 函数
- 微调工作流