### PR TITLE
Update the ref link of "PPA"

### DIFF
--- a/chapter/addition.tex
+++ b/chapter/addition.tex
@@ -138,7 +138,7 @@ Webdings
 \end{lstlisting}
 即完成换源.
 有时地址太多而逐个换太麻烦,
-可以直接使用如下命令直接替换\footnote{参见 \url{https://mogeko.me/posts/zh-cn/035/}}
+可以直接使用如下命令直接替换\footnote{参见 \url{https://mogeko.me/zh-cn/posts/zh-cn/035/}}
 \begin{lstlisting}[deletekeywords = apt]
   sudo find /etc/apt/sources.list.d/ -type f -name "*.list" -exec  sed  -i.bak -r  's#deb(-src)?\s*http(s)?://ppa.launchpad.net#deb\1 https\2://launchpad.proxy.ustclug.org#ig' {} \;
 \end{lstlisting}


### PR DESCRIPTION
"使用中科大反向代理给 PPA 加速" 的教程链接需要更新：作者更改了自己主页服务器的目录，多了一层 "zh-cn"，不然直接404 File not found