### PR TITLE
微调部分格式与描述

### DIFF
--- a/chapter/mirror.tex
+++ b/chapter/mirror.tex
@@ -36,7 +36,7 @@
     & \url{https://mirrors.bfsu.edu.cn/CTAN/systems/texlive/}\\
     \href{https://mirrors.cqu.edu.cn/}{重庆大学}
     & \url{https://mirrors.cqu.edu.cn/CTAN/systems/texlive/}\\
-    \href{https://help.mirrors.cernet.edu.cn/CTAN/}{高校联合镜像源}
+    \href{https://help.mirrors.cernet.edu.cn/}{高校联合镜像}
     & \url{https://mirrors.cernet.edu.cn/CTAN/systems/texlive/}\\
     \href{https://mirrors.hust.edu.cn/}{华中科技大学}
     & \url{https://mirrors.hust.edu.cn/CTAN/systems/texlive/}\\

--- a/chapter/mirror.tex
+++ b/chapter/mirror.tex
@@ -14,7 +14,7 @@
 我将列表中位于大陆地区的源整理到表~\ref{tab:appendix:mirror},
 并将我个人收集到的其他大陆地区的源整理到表~\ref{tab:appendix:mirror-addition}.
 其中,
-\href{https://help.mirrors.cernet.edu.cn/CTAN/}{高校联合镜像}%
+\href{https://help.mirrors.cernet.edu.cn/}{高校联合镜像}%
 是一个仿照
 \href{https://mirrors.ctan.org/systems/texlive/}{CTAN 镜像}%
 的国内镜像源,

--- a/chapter/preface.tex
+++ b/chapter/preface.tex
@@ -77,16 +77,17 @@
 \definecolor{alipay}{HTML}{1677FF}
 \definecolor{weixin}{HTML}{1AAD19}
 \begin{center}
-  \fancyqr[ classic, height = 5.55em, color = black, version = 5, image = {\tikz
-            \node [ inner sep = 0pt, draw, line width = .1em,
-                    rounded corners = .225em, alipay,
+  \fancyqr[ classic, height = 6em, color = black, version = 5, image = {\tikz
+            \node [ inner sep = 0pt, rounded corners = .225em, 
+                    draw, line width = .1em, alipay,
                     minimum width = .95em, minimum height = .95em
                   ] {\textcolor{alipay}\faAlipay};}
           ]{https://qr.alipay.com/fkx10265yq7niozotwocae3}%
   \qquad
-  \fancyqr[ classic, height = 5.55em, color = black, version = 5, image = {\tikz
-            \node [ inner sep = 0pt, fill = weixin, rounded corners = .225em,
+  \fancyqr[ classic, height = 6em, color = black, version = 5, image = {\tikz
+            \node [ inner sep = 0pt, rounded corners = .225em,
+                    fill = weixin, font = \footnotesize,
                     minimum width = 1.05em, minimum height = 1.05em
-                  ] (wechat) {\footnotesize\textcolor{white}\faWeixin};}
+                  ] (wechat) {\textcolor{white}\faWeixin};}
           ]{wxp://f2f1ngYJgHLcAYkvo8VUlpSbF5_J5KiktdpOGmnA0ienTGgAgR2x20yWxEjzHWmIZfcT}
 \end{center}


### PR DESCRIPTION
- 调整二维码代码格式
- 统一"高校联合镜像"的超链接："高校联合镜像"这几个字同"XX大学"一样，指的是这个镜像源一级页面，而非这个镜像源的 CTAN 目录，毕竟对应的子目录 url 已经在每个镜像源前描述过了. 例如别的镜像源写的都是
```tex
\href{https://mirrors.hust.edu.cn/}{华中科技大学}
```
而不是
```tex
\href{https://mirrors.hust.edu.cn/CTAN}{华中科技大学}
```