### PR TITLE
build.lua 的 description key 中: "Ubuntu 22.04" 改为 "Ubuntu 24.04"

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -17,7 +17,7 @@ repository       = "https://github.com/" .. maintainid .. "/" .. module
 announcement     = ""
 summary          = "A short introduction to LaTeX installation written in Chinese"
 description      = [[
-This package will introduce the operations related to installing TeX Live (introducing MacTeX in macOS), upgrading packages, and compiling simple documents on Windows 11, Ubuntu 22.04, and macOS systems, and mainly introducing command line operations.
+This package will introduce the operations related to installing TeX Live (introducing MacTeX in macOS), upgrading packages, and compiling simple documents on Windows 11, Ubuntu 24.04, and macOS systems, and mainly introducing command line operations.
 ]]
 
 --[==========================================[--

--- a/build.lua
+++ b/build.lua
@@ -15,6 +15,7 @@ maintainid       = "OsbertWang"
 email            = "ranwang.osbert@outlook.com"
 repository       = "https://github.com/" .. maintainid .. "/" .. module
 announcement     = ""
+note             = ""
 summary          = "A short introduction to LaTeX installation written in Chinese"
 description      = [[
 This package will introduce the operations related to installing TeX Live (introducing MacTeX in macOS), upgrading packages, and compiling simple documents on Windows 11, Ubuntu 24.04, and macOS systems, and mainly introducing command line operations.
@@ -42,6 +43,7 @@ uploadconfig = {
   summary      = summary,
   description  = description,
   announcement = announcement,
+  note         = note,
   license      = "lppl1.3c",  
   ctanPath     = "/info/" .. module,
   home         = repository,


### PR DESCRIPTION
- P.S.: 根据经验，CTAN 在每次上传时，如果你不提，他们似乎并不会去给你更新 description 和 summary 等内容. 所以我在 `build.lua` 的第 18 行加了个 `note` 键：可在上传前在 `note = ""` 的 `"..."` 中输入备注（该备注仅CTAN 可见），提醒他们更新下 description (可以写譬如：`note = "The description of this package has been modified. Remember to sync on the homepage of this package."` 类似的这样一句话).