### PR TITLE
Updated the version of `fontawesome` from 6 to 7; Changed the link for `WinEdt` (The former one is `404` now); Optimized some spaces in `.tex` file

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -11,7 +11,7 @@ booktabs
 ctex
 fancyqr
 fancyvrb
-fontawesome6
+fontawesome7
 geometry
 hologo
 hyperref

--- a/chapter/editor.tex
+++ b/chapter/editor.tex
@@ -580,8 +580,8 @@ Mac\TeX\ 自带 \TeX Shop 编辑器 (注意不要与其他自带的程序混淆)
     主流系统 & Win      &  全平台   & Linux/Win  &  全平台   & 全平台  \\
     软件类型 & 商业软件 &  开源软件 & 开源软件   &  商业软件 & 开源软件\\
     软件价格 &
-    \href{https://store.lizhi.io/site/products/id/260?cid=svg2pcwp}{179 元} &
-    0 & 0 & \href{https://www.sublimehq.com/store/text}{99 美元} & 0   \\
+    \href{https://lizhi.shop/products/winedt}{179 元} & 0 & 0 &
+    \href{https://www.sublimehq.com/store/text}{99 美元} & 0   \\
     授权方式 & 终身/教育 & & & 终身/个人 & \\
     代码高亮 &
     \stars{2.7} & \stars{3.2} & \stars{1.5} & \stars{4.3} & \stars{4.5}\\

--- a/chapter/editor.tex
+++ b/chapter/editor.tex
@@ -125,7 +125,7 @@ Windows 11 中字体列表见%
 下载 \texttt{.oxt} 文件.
 将 \texttt{.oxt} 文件重命名为 \texttt{.zip} 文件,
 解压缩得到里面的 \texttt{.dic} 和 \texttt{.aff} 文件.
-接下来将它们安装到 \path{<resources>\dictionaries}
+接下来将它们安装到 \path{<resources>\dictionaries}%
 \footnote{\path{<resources>} 的具体位置可以在
 \menu{帮助 > TeXworks 配置与资源} 中找到,
 若不存在该 \path{dictionaries} 文件夹,

--- a/chapter/overleaf.tex
+++ b/chapter/overleaf.tex
@@ -95,13 +95,14 @@ Overleaf 将后台 \TeX~Live 升级后,
 \subsection{学习与帮助}
 
 Overleaf 的%
-\href{https://www.overleaf.com/latex/templates}{模板}和%
+\href{https://www.overleaf.com/latex/templates}{模板}%
+和%
 \href{https://www.overleaf.com/learn}{文档}%
 对全网公开,
 用户可以自行学习.
 另外 Overleaf 有着专业的技术支援团队,
-用户可发送邮件至 \href{mailto:support@overleaf.com}%
-{\texttt{support@overleaf.com}}
+用户可发送邮件至
+\href{mailto:support@overleaf.com}{\texttt{support@overleaf.com}}%
 咨询使用过程中遇到的问题,
 在邮件中请注意文明用语.
 部分问题会超出免费服务的范畴,

--- a/install-latex-guide-zh-cn.tex
+++ b/install-latex-guide-zh-cn.tex
@@ -12,7 +12,7 @@
 
 \usepackage[margin = 2.4cm]{geometry}
 \usepackage{booktabs, array}
-\usepackage{fontawesome6, fancyqr, hologo}
+\usepackage{fontawesome7, fancyqr, hologo}
 \usepackage[colorlinks, pdfpagelayout = SinglePage, bookmarksnumbered]{hyperref}
 
 \usepackage{tikz}


### PR DESCRIPTION
- Updated the version of `fontawesome` from 6 to 7
- Changed the link for `WinEdt` (The former one is `404` now)
- Optimized some spaces in `.tex` file.
---
- 将 `fontawesome` 版本从 6 升级到 7
- 更改 `WinEdt` 购买链接（旧链接已失效）
- 更改 `.tex` 文件中的部分空格